### PR TITLE
Fix: 'firewalld' was missing in Containerfile

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -2,6 +2,7 @@ FROM registry.redhat.io/rhel9/rhel-bootc:9.5-1736459892
 ADD index.html /var/www/html/index.html
 RUN dnf -y install httpd \
     openssh-server \
+    firewalld \
     bind-utils \
     net-tools \
     chrony \
@@ -14,4 +15,4 @@ RUN dnf -y install httpd \
     bash-completion && \
     dnf clean all
 RUN mandb
-RUN systemctl enable httpd sshd
+RUN systemctl enable httpd sshd firewalld


### PR DESCRIPTION
Hi,

I stumbled upon this when using this repo instead of copy and past the files from the blog. :)

